### PR TITLE
Set up AI working environment (CLAUDE.md / CI / allowlist)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run lint *)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           name: resume.en
           path: ikuwow_resume.en.pdf
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,11 @@ jobs:
           node-version-file: "package.json"
       - run: npm ci
       - run: npm run pdf
-      - uses: softprops/action-gh-release@v3
-        with:
-          files: ikuwow_resume.ja.pdf
-        env:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run pdf-en
       - uses: softprops/action-gh-release@v3
         with:
-          files: ikuwow_resume.en.pdf
+          files: |
+            ikuwow_resume.ja.pdf
+            ikuwow_resume.en.pdf
         env:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.pdf
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,22 +21,38 @@ This is ikuwow's resume repository that generates both Japanese and English resu
 
 ## Repository Structure
 
-- `resume.ja.md` - Japanese resume source
-- `resume.en.md` - English resume source
+- `resume.ja.md` - Japanese resume source (master)
+- `resume.en.md` - English resume source (machine-translated from `resume.ja.md`)
 - `style.css` - Custom styling for PDF generation
 - `md-to-pdf.json` - PDF generation configuration
 - `.textlintrc` - Japanese text linting rules configuration
 
+## Authoring Rules
+
+These constraints exist in the content itself or in the publishing flow. Follow them when editing the resume Markdown.
+
+- `resume.ja.md` is the source of truth. `resume.en.md:3` declares that in case of conflict the Japanese version prevails. Any change to `resume.ja.md` must include the corresponding update to `resume.en.md` in the same PR.
+- The "as of" date at the top of each file must be updated to today's date whenever the body is changed:
+  - `resume.ja.md:3` — `YYYY年MM月DD日現在`
+  - `resume.en.md:5` — `As of Month DD, YYYY`
+- The email address is intentionally obfuscated as `ikuwow(at)gmail.com` in both files. Do not change `(at)` to `@`.
+- Do not commit generated PDFs or local build artifacts. They are covered by `.gitignore` (`*.pdf`).
+- `.textlintrc` sets `sentence-length.max` to 201; the value is intentional. Do not lower it to "fix" long-sentence warnings — rewrite the sentence instead.
+
 ## Development Workflow
 
-1. Edit the appropriate Markdown file (resume.ja.md or resume.en.md)
-2. Use watch commands during editing for live preview
-3. Run `npm run lint` before committing to ensure text quality
-4. Generate final PDFs with `npm run pdf` and `npm run pdf-en`
+1. Edit `resume.ja.md` first, then mirror the change into `resume.en.md`.
+2. Update the "as of" date in both files.
+3. Run `npm run lint` before committing. Watch-mode commands (`pdf-watch`, `pdf-en-watch`) are long-running processes; do not invoke them from an automated agent — they are for humans editing locally.
+4. PDF generation is normally handled by CI (see below). Run `npm run pdf` / `npm run pdf-en` locally only when you need to verify the rendered output yourself.
+
+## Release Process
+
+Pushing a tag matching `v*` (e.g., `v2026.05.17`) triggers `.github/workflows/release.yml`, which builds both PDFs and attaches them to a GitHub Release. The README links (`releases/latest/download/...`) point at the latest release, so tagging is the publishing step.
 
 ## GitHub Actions
 
-The repository uses GitHub Actions for:
-- Automatic PDF generation on push
-- Linting checks
-- Creating releases with PDF artifacts
+- `.github/workflows/main.yml` — On every push: builds both PDFs (macOS runner, required for Hiragino Sans) and uploads them as artifacts; runs textlint on a Linux runner.
+- `.github/workflows/release.yml` — On `v*` tag push: builds both PDFs and attaches them to a GitHub Release.
+- `.github/workflows/dependabot-auto-merge.yml` — Auto-merges Dependabot PRs for `semver-patch` and `semver-minor` updates. Major updates still require manual review.
+- `.github/dependabot.yml` — Monthly schedule for npm and GitHub Actions ecosystems.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,11 @@ This is ikuwow's resume repository that generates both Japanese and English resu
 
 These constraints exist in the content itself or in the publishing flow. Follow them when editing the resume Markdown.
 
-- `resume.ja.md` is the source of truth. `resume.en.md:3` declares that in case of conflict the Japanese version prevails. Any change to `resume.ja.md` must include the corresponding update to `resume.en.md` in the same PR.
+- `resume.ja.md` is the source of truth. `resume.en.md` declares near the top that in case of conflict the Japanese version prevails.
+- Any change to `resume.ja.md` must include the corresponding update to `resume.en.md` in the same PR.
 - The "as of" date at the top of each file must be updated to today's date whenever the body is changed:
-  - `resume.ja.md:3` — `YYYY年MM月DD日現在`
-  - `resume.en.md:5` — `As of Month DD, YYYY`
+  - `resume.ja.md` — the `YYYY年MM月DD日現在` line near the top
+  - `resume.en.md` — the `As of Month DD, YYYY` line near the top
 - The email address is intentionally obfuscated as `ikuwow(at)gmail.com` in both files. Do not change `(at)` to `@`.
 - Do not commit generated PDFs or local build artifacts. They are covered by `.gitignore` (`*.pdf`).
 - `.textlintrc` sets `sentence-length.max` to 201; the value is intentional. Do not lower it to "fix" long-sentence warnings — rewrite the sentence instead.
@@ -52,7 +53,7 @@ Pushing a tag matching `v*` (e.g., `v2026.05.17`) triggers `.github/workflows/re
 
 ## GitHub Actions
 
-- `.github/workflows/main.yml` — On every push: builds both PDFs (macOS runner, required for Hiragino Sans) and uploads them as artifacts; runs textlint on a Linux runner.
+- `.github/workflows/main.yml` — On every push: builds both PDFs (macOS runner, required for the Hiragino Sans font selected in `style.css`) and uploads them as artifacts; runs textlint on a Linux runner.
 - `.github/workflows/release.yml` — On `v*` tag push: builds both PDFs and attaches them to a GitHub Release.
 - `.github/workflows/dependabot-auto-merge.yml` — Auto-merges Dependabot PRs for `semver-patch` and `semver-minor` updates. Major updates still require manual review.
 - `.github/dependabot.yml` — Monthly schedule for npm and GitHub Actions ecosystems.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "engines": {
     "node": "22"
   },
-  "main": "index.js",
   "scripts": {
     "lint": "textlint .",
     "pdf": "md-to-pdf resume.ja.md --config-file md-to-pdf.json",


### PR DESCRIPTION
## Why

Set up the repo for Claude Code-driven editing, and clean up a few CI cost / shape issues in the same area.

## What changed

- CLAUDE.md: Authoring Rules + Release Process sections (ja-master, en sync, "as of" date, `(at)` email, watch-mode guard, `.textlintrc` sentence-length, dependabot).
- `main.yml`: lint job → `ubuntu-latest` (textlint needs no Japanese fonts).
- `release.yml`: one `action-gh-release` call with multi-file `files: |`.
- `package.json`: drop dead `"main": "index.js"`.
- `.claude/settings.json` (new) + `.gitignore`: allowlist for `npm run lint`; ignore local settings.

## Verification

- [x] `npm run lint` passes.
- [x] CI `build` (macOS) / `lint` (ubuntu) green.
- [ ] `release.yml` — only fires on `v*` tag, untested here.
- [ ] `.claude/settings.json` effect — confirmed next session.
