### PR TITLE
resume.ja.md: ポートフォリオ寄りに再構成

### DIFF
--- a/resume.en.md
+++ b/resume.en.md
@@ -222,7 +222,7 @@ Worked as an intern from September 2013 to March 2015
 * Developing new iOS applications
 * Conducting seminars for student engineers
 
-## Publications
+## Writing
 
 * [tacoms tech blog](https://tacoms-inc.hatenablog.com/archive/author/ikuwow) Tech blog articles, 2024–
 * [Former tacoms tech blog](https://zenn.dev/p/tacoms) Tech blog articles
@@ -230,8 +230,6 @@ Worked as an intern from September 2013 to March 2015
 * SoftwareDesign series "アプリエンジニアのための［インフラ］入門 (Infrastructure Basics for Application Engineers)", all 6 parts, 2016
 * gihyo.jp [あとはコードを書くだけ，はじめに作る開発環境構築ベストプラクティス (Development Environment Setup Best Practices)](https://gihyo.jp/dev/serial/01/howto-env-conf), 2016
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎 (Programming Fundamentals)](https://gihyo.jp/dev/serial/01/js-foundation), (3rd, 5th, 7th parts), 2015
-* Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT), Jan. 2014
-* Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
 
 ## Certifications
 

--- a/resume.en.md
+++ b/resume.en.md
@@ -222,7 +222,7 @@ Worked as an intern from September 2013 to March 2015
 * Developing new iOS applications
 * Conducting seminars for student engineers
 
-## Writing, Talks & OSS
+## Publications
 
 * [tacoms tech blog](https://tacoms-inc.hatenablog.com/archive/author/ikuwow) Tech blog articles, 2024–
 * [Former tacoms tech blog](https://zenn.dev/p/tacoms) Tech blog articles
@@ -232,7 +232,6 @@ Worked as an intern from September 2013 to March 2015
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎 (Programming Fundamentals)](https://gihyo.jp/dev/serial/01/js-foundation), (3rd, 5th, 7th parts), 2015
 * Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT), Jan. 2014
 * Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
-* OSS contributions on [GitHub](https://github.com/ikuwow)
 
 ## Certifications
 

--- a/resume.en.md
+++ b/resume.en.md
@@ -8,6 +8,8 @@ As of June 2026
 
 Ikuo Degawa (@ikuwow)
 
+SRE / Platform Engineer
+
 Born in 1990, lives in Kanagawa, Japan
 
 * X: https://x.com/ikuwow
@@ -17,60 +19,50 @@ Born in 1990, lives in Kanagawa, Japan
 
 The latest version of this resume is available on GitHub: https://github.com/ikuwow/resume
 
+## Summary
+
+I have worked for many years as an SRE and platform engineer at web companies, building the reliability and delivery foundations of services.
+I specialize in SLO/SLI operations on AWS, GitOps and progressive delivery, and the design, construction, and operation of microservice platforms with Kubernetes and Istio.
+Working across job roles and technical domains, I pursue holistic problem-solving that factors in technical, organizational, and cost trade-offs.
+I always act with the goals of the project or service and the value to users in mind.
+
 ## Skills
 
-* Experience in SRE and DevOps for web applications
-  * Building and maintaining CI/CD environments using CircleCI, TravisCI, GitHub Actions, etc.
-  * Designing and operating GitOps and progressive delivery using PipeCD, etc.
-  * Managing development projects using GitHub, etc.
-  * Supporting the structure of development teams and practicing Enabling SRE
-  * Solving problems across applications and promoting projects
-  * Leadership in incident response
-  * Practicing SRE principles like 50% rule, post-mortems, etc.
-  * Setting up and operating SLO/SLI and error budget policies
-  * Designing and building observability tooling using Datadog, etc.
-* Experience in building and managing infrastructure, managing middleware
-  * Basic knowledge of networking and infrastructure technology
-  * Utilizing cloud platforms like AWS, GCP
-  * Building and operating infrastructure using IaC with Terraform, Ansible, Chef, etc.
-  * Experience with Docker, Kubernetes and ECS in production environments
-  * Designing, building, and operating microservice architectures with Kubernetes and Istio
-  * Operating applications in a microservices environment
-  * Designing, improving performance, and managing RDBs like PostgreSQL, MySQL
-  * Building office networks
-* Backend development skills
-  * Experience in programming languages like PHP, Ruby, Java, JavaScript, Golang
-  * Experience with frameworks like CakePHP, Ruby on Rails, Spring
-* Frontend development skills
-  * Experience in frontend development using HTML/CSS/JavaScript
-  * Building and maintaining frontend projects with Sass, Webpack
-  * Performance monitoring and improvement
-  * Building frontend observability tooling using RUM tools
-* Others
-  * Building data analysis environments using Elasticsearch, Kibana, Redshift, BigQuery, Tableau, etc.
-  * Experience in developing iOS applications with Swift
-  * Image processing and audio processing programming with MATLAB and C
-  * Customizing CMS like WordPress
+### Core (Reliability & Delivery Platform)
+
+* SRE / DevOps practice (building and operating CI/CD environments, leadership in incident response, practices such as postmortems and the 50% rule, Enabling SRE)
+* Establishing and operating SLO/SLI and error budget policies
+* Designing and building observability tooling (Datadog, etc.)
+* Designing and operating GitOps and progressive delivery (PipeCD, Flagger, Flux, etc.)
+* Designing, building, and operating microservice architectures with Kubernetes and Istio
+* Building and operating AWS-centered cloud infrastructure
+* Developing and operating backend applications in Golang
+* Hands-on technical validation and PoC
+* Utilizing AI coding agents, and designing and introducing development processes premised on AI agents
+
+### Experience
+
+* Languages & frameworks: PHP, Ruby on Rails, Java/Spring, JavaScript, Golang, CakePHP
+* Cloud & infrastructure: AWS, GCP, Terraform, Ansible, Chef, Docker, Kubernetes, ECS
+* Datastores & analytics: PostgreSQL, MySQL, Elasticsearch, Redshift, BigQuery, Tableau
+* Frontend: HTML/CSS/JavaScript, Sass, Webpack, observability and performance improvement with RUM
+* Other: fundamentals of networking and infrastructure, office network setup, reading/writing/listening in English
+
+### Background
+
+* Image and audio processing programming with MATLAB and C
+* iOS app development with Swift
+* Customizing CMS such as WordPress
 
 <div class="page-break"></div>
-
-## Capabilities
-
-* Always acting with the project's or service's goals in mind
-* Solving problems across job roles and technical domains with overall optimization in mind, factoring in technology, organizational, and cost trade-offs
-* Conducting hands-on technical validation/PoC
-* Utilizing AI coding agents and setting up their environments
-* Designing and introducing development processes premised on AI agents
-* Smooth asynchronous communication using GitHub, documentation tools, and messaging tools
-* Valuing morals and user value
-* Reading, writing, and listening in English
-* Contributing to OSS
 
 ## Work Experience
 
 ### tacoms Inc.
 
 Worked as a contractor from June 2024 to July 2025, then as a full-time employee from August 2025 to present
+
+As the SRE tech lead, driving the reliability, delivery, and cost of the restaurant order management SaaS "Camel" across the board
 
 #### SRE Member / Tech Lead
 
@@ -103,6 +95,8 @@ Worked as a contractor from June 2024 to July 2025, then as a full-time employee
 ### ZOZO, Inc.
 
 Worked as a full-time employee from December 2021 to April 2024 in a fully remote capacity
+
+Served as a platform SRE for a large-scale EC service, and as the lead SRE for a core system replacement
 
 #### Platform Services SRE Block, Front SRE Block
 
@@ -138,12 +132,12 @@ Worked as a full-time employee from December 2021 to April 2024 in a fully remot
 * Lecturing SRE and development teams on post-replacement technologies
 * Conducting pre-release load testing
 
-<div class="page-break"></div>
-
 ### SMS Co., Ltd.
 
 Worked as a full-time employee from October 2017 to November 2021
 (Worked fully remotely from 2020)
+
+As the SRE for the elderly care management support SaaS "Kaipoke" and other services
 
 #### Development and support for an internal LP hosting service, and others
 
@@ -228,7 +222,7 @@ Worked as an intern from September 2013 to March 2015
 * Developing new iOS applications
 * Conducting seminars for student engineers
 
-## Publications
+## Writing, Talks & OSS
 
 * [tacoms tech blog](https://tacoms-inc.hatenablog.com/archive/author/ikuwow) Tech blog articles, 2024–
 * [Former tacoms tech blog](https://zenn.dev/p/tacoms) Tech blog articles
@@ -238,6 +232,7 @@ Worked as an intern from September 2013 to March 2015
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎 (Programming Fundamentals)](https://gihyo.jp/dev/serial/01/js-foundation), (3rd, 5th, 7th parts), 2015
 * Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT), Jan. 2014
 * Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
+* OSS contributions on [GitHub](https://github.com/ikuwow)
 
 ## Certifications
 

--- a/resume.en.md
+++ b/resume.en.md
@@ -21,7 +21,7 @@ The latest version of this resume is available on GitHub: https://github.com/iku
 
 ## Summary
 
-I have worked for many years as an SRE and platform engineer at web companies, building the reliability and delivery foundations of services.
+I have worked for many years as an SRE and platform engineer at web companies, building the reliability and delivery platforms of services.
 I specialize in SLO/SLI operations on AWS, GitOps and progressive delivery, and the design, construction, and operation of microservice platforms with Kubernetes and Istio.
 Working across job roles and technical domains, I pursue holistic problem-solving that factors in technical, organizational, and cost trade-offs.
 I always act with the goals of the project or service and the value to users in mind.
@@ -38,11 +38,11 @@ I always act with the goals of the project or service and the value to users in 
 * Building and operating AWS-centered cloud infrastructure
 * Developing and operating backend applications in Golang
 * Hands-on technical validation and PoC
-* Utilizing AI coding agents, and designing and introducing development processes premised on AI agents
+* Leveraging AI coding agents, and designing and introducing development processes built around AI agents
 
-### Experience
+### Proficient
 
-* Languages & frameworks: PHP, Ruby on Rails, Java/Spring, JavaScript, Golang, CakePHP
+* Languages & frameworks: Golang, Java/Spring, Ruby on Rails, JavaScript, PHP, CakePHP
 * Cloud & infrastructure: AWS, GCP, Terraform, Ansible, Chef, Docker, Kubernetes, ECS
 * Datastores & analytics: PostgreSQL, MySQL, Elasticsearch, Redshift, BigQuery, Tableau
 * Frontend: HTML/CSS/JavaScript, Sass, Webpack, observability and performance improvement with RUM
@@ -66,17 +66,17 @@ As the SRE tech lead, driving the reliability, delivery, and cost of the restaur
 
 #### SRE Member / Tech Lead
 
+* Designing and implementing migration from CIOps (GitHub Actions → ECR → ECS) to GitOps (PipeCD)
+* Introducing canary release / progressive delivery using PipeCD
+* Building and promoting observability tooling using Datadog
 * Operating AWS service infrastructure using ECS Fargate, Aurora, SQS/SNS, Lambda, etc.
+* Building and operating infrastructure for new services
+* Designing and building infrastructure for detecting integration errors with external services (Lambda, EventBridge, Datadog)
 * Performance optimization of Aurora MySQL
 * Designing and building the data aggregation infrastructure using BigQuery, etc.
-* Building and operating infrastructure for new services
-* Designing and implementing migration from CIOps (GitHub Actions → ECR → ECS) to GitOps (PipeCD)
-* Building and promoting observability tooling using Datadog
 * Evaluating TiDB migration
-* Introducing canary release / progressive delivery using PipeCD
-* Designing and building infrastructure for detecting integration errors with external services (Lambda, EventBridge, Datadog)
 * Handling traffic spikes from customer campaigns
-* Building infrastructure for AI utilization
+* Building a platform to support AI/LLM workloads
 * Various incident response and on-call
 
 #### Development and operation of "Camel", a restaurant order management SaaS
@@ -96,9 +96,9 @@ As the SRE tech lead, driving the reliability, delivery, and cost of the restaur
 
 Worked as a full-time employee from December 2021 to April 2024 in a fully remote capacity
 
-Served as a platform SRE for a large-scale EC service, and as the lead SRE for a core system replacement
+Served as a platform SRE for a large-scale EC service, and as the lead SRE for a core system re-platforming
 
-#### Platform Services SRE Block, Front SRE Block
+#### Platform SRE and Frontend SRE teams
 
 * Designing, building, and operating Kubernetes infrastructure
 * Operating microservice applications on a service mesh using Istio
@@ -112,25 +112,21 @@ Served as a platform SRE for a large-scale EC service, and as the lead SRE for a
 * On-call duties, incident response
 * Mentoring new employees
 
-#### Lead SRE for Core System Replacement
+#### Lead SRE for Core System Re-platforming
 
-* Catching up on domain knowledge and translating it into requirements
 * Conducting PoC, designing, and building data integration methods using Kafka (Amazon MSK, etc.)
-* Task and schedule management
+* Catching up on domain knowledge and translating it into requirements
 * Logical design of RDBs
-* Building release flows and lecturing development teams
-* Adhering to various guidelines including security
-* Lecturing SRE and development teams on post-replacement technologies
+* Task and schedule management
+* Building release flows and running training sessions for the development teams
+* Adhering to internal security and compliance guidelines
+* Onboarding the SRE and development teams onto the new stack
 * Conducting pre-release load testing
 
-#### Frontend Replacement Project
+#### Frontend Re-platforming Project
 
 * Designing, building, and operating NodeJS applications on microservice infrastructure
 * Designing WAF and routing on Akamai
-* Building release flows and lecturing development teams
-* Adhering to various guidelines including security
-* Lecturing SRE and development teams on post-replacement technologies
-* Conducting pre-release load testing
 
 ### SMS Co., Ltd.
 
@@ -170,6 +166,8 @@ October 2017 - July 2020
 
 Worked as a freelance engineer from April 2018 to June 2021 in a fully remote capacity
 
+Supported the team running the 1-on-1 tool TeamUp as a contractor, owning infrastructure setup and development-process foundations
+
 #### Infrastructure setup and support for establishing development systems for 1-on-1 tool TeamUp
 
 April 2018 - June 2021
@@ -188,26 +186,28 @@ April 2018 - June 2021
 
 Worked as a full-time employee from April 2015 to September 2017
 
+Worked mainly on the engineer-focused Q&A service "teratail", spanning web application development, infrastructure, and data analytics platforms
+
 #### Development of engineer-oriented Q&A service "teratail" and others
 
 April 2015 - September 2017
 
 * Developing and maintaining CakePHP applications
 * Designing and building public REST APIs
-* Developing the entire frontend for campaign pages
-* Setting up CI environment
-* Considering measures to achieve business goals
-* Building analysis infrastructure using Elasticsearch, Redshift, BigQuery, etc.
 * Migrating from VPC to GKE (Kubernetes) environment
 * Improving application performance overall
+* Developing the entire frontend for campaign pages
+* Setting up CI environment
+* Planning initiatives to achieve business goals
+* Building analysis infrastructure using Elasticsearch, Redshift, BigQuery, etc.
 * Introducing and connecting Mailchimp system with the application for newsletters
 * Introducing and managing Google's advertising system (Google Adwords)
+* Awarded Excellent Hacker Award in 2015
 * Others
   * Designing, building, and managing internal networks
   * Writing content articles
   * Building and directing newsletter content
   * Participating in recruitment activities
-  * Awarded Excellent Hacker Award in 2015
 
 ### Slogan, Inc.
 
@@ -218,7 +218,7 @@ Worked as an intern from September 2013 to March 2015
 * Developing user-facing CakePHP applications
 * Developing admin-facing CakePHP applications
 * Replacing VPC environments using Chef, etc.
-* Building and maintaining office/office-to-office networks
+* Building and maintaining office and inter-office (site-to-site) networks
 * Developing new iOS applications
 * Conducting seminars for student engineers
 

--- a/resume.ja.md
+++ b/resume.ja.md
@@ -19,11 +19,11 @@ SRE / Platform Engineer
 
 ## 概要
 
-Web系企業で SRE・プラットフォームエンジニアとして、サービスの信頼性とデリバリー基盤づくりに長く携わってきました。AWS を基盤とした SLO/SLI 運用、GitOps・プログレッシブデリバリー、Kubernetes・Istio によるマイクロサービス基盤の設計・構築・運用を得意としています。職種や技術領域をまたいで、技術・組織・コストのトレードオフを踏まえた全体最適な問題解決に取り組み、常にプロジェクトやサービスの目的とユーザーへの価値を見据えて行動することを大切にしています。GitHub やドキュメンテーション・メッセージングツールを活用した非同期コミュニケーションを基本としています。現在は飲食店向け SaaS「Camel」のテックリードとして、信頼性・デリバリー・コストを横断的に推進しています。
+Web系企業で SRE・プラットフォームエンジニアとして、サービスの信頼性とデリバリー基盤づくりに長く携わってきました。
+AWS を基盤とした SLO/SLI 運用、GitOps・プログレッシブデリバリー、Kubernetes・Istio によるマイクロサービス基盤の設計・構築・運用を得意としています。
+職種や技術領域をまたいで、技術・組織・コストのトレードオフを踏まえた全体最適な問題解決に取り組み、常にプロジェクトやサービスの目的とユーザーへの価値を見据えて行動します。
 
 ## スキル
-
-習熟度の高い順に記載しています。
 
 ### コア（信頼性・デリバリー基盤）
 
@@ -39,16 +39,11 @@ Web系企業で SRE・プラットフォームエンジニアとして、サー�
 
 ### 実務経験
 
-* プログラミング言語: PHP, Ruby, Java, JavaScript, Golang
-* フレームワーク: CakePHP, Ruby on Rails, Spring
-* IaC・構成管理: Terraform, Ansible, Chef
-* コンテナ・オーケストレーション: Docker, Kubernetes, ECS
-* クラウド: AWS, GCP
-* RDB: PostgreSQL, MySQL の設計・パフォーマンス改善・管理
-* フロントエンド: HTML/CSS/JavaScript, Sass, Webpack、RUM ツールによる観測とパフォーマンス改善
-* データ分析基盤: Elasticsearch, Kibana, Redshift, BigQuery, Tableau
-* ネットワーク・インフラの基礎知識、オフィスネットワークの構築
-* 英語での読み書き・リスニング、技術ドキュメントの読解
+* 言語・フレームワーク: PHP, Ruby on Rails, Java/Spring, JavaScript, Golang, CakePHP
+* クラウド・基盤: AWS, GCP, Terraform, Ansible, Chef, Docker, Kubernetes, ECS
+* データストア・分析基盤: PostgreSQL, MySQL, Elasticsearch, Redshift, BigQuery, Tableau
+* フロントエンド: HTML/CSS/JavaScript, Sass, Webpack, RUM による観測・パフォーマンス改善
+* その他: ネットワーク・インフラの基礎知識、オフィスネットワーク構築、英語の読み書き・リスニング
 
 ### バックグラウンド・周辺
 
@@ -64,7 +59,7 @@ Web系企業で SRE・プラットフォームエンジニアとして、サー�
 
 業務委託として2024年6月〜2025年7月、正社員として2025年8月から現在まで勤務
 
-飲食店向け注文管理 SaaS「Camel」のテックリードとして、信頼性・デリバリー・コストを横断的に推進
+SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」の信頼性・デリバリー・コストを横断的に推進
 
 #### SREメンバー/テックリード
 

--- a/resume.ja.md
+++ b/resume.ja.md
@@ -219,7 +219,7 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 * iOSアプリの新規開発
 * 学生エンジニア向けセミナー講師
 
-## 執筆・発表・OSS
+## 執筆
 
 * [tacoms テックブログ](https://tacoms-inc.hatenablog.com/archive/author/ikuwow) テックブログ執筆 2024年〜
 * [旧tacoms テックブログ](https://zenn.dev/p/tacoms) テックブログ執筆
@@ -229,7 +229,6 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎](https://gihyo.jp/dev/serial/01/js-foundation)（第3,5,7回）2015年
 * Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT) , Jan. 2014
 * Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
-* [GitHub](https://github.com/ikuwow) 上での OSS へのコントリビュート
 
 ## 資格
 

--- a/resume.ja.md
+++ b/resume.ja.md
@@ -39,7 +39,7 @@ AWS を基盤とした SLO/SLI 運用、GitOps・プログレッシブデリバ�
 
 ### 実務経験
 
-* 言語・フレームワーク: PHP, Ruby on Rails, Java/Spring, JavaScript, Golang, CakePHP
+* 言語・フレームワーク: Golang, Java/Spring, Ruby on Rails, JavaScript, PHP, CakePHP
 * クラウド・基盤: AWS, GCP, Terraform, Ansible, Chef, Docker, Kubernetes, ECS
 * データストア・分析基盤: PostgreSQL, MySQL, Elasticsearch, Redshift, BigQuery, Tableau
 * フロントエンド: HTML/CSS/JavaScript, Sass, Webpack, RUM による観測・パフォーマンス改善
@@ -63,15 +63,15 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 
 #### SREメンバー/テックリード
 
+* CIOps（GitHub Actions → ECR → ECS）からGitOps (PipeCD) への移行設計・実装
+* PipeCDを用いたcanary release / progressive deliveryの導入
+* Datadogを用いた可観測性を担う仕組みの構築、推進
 * ECS Fargate, Aurora, SQS/SNS, Lambdaを利用したAWSサービス基盤の運用
+* 新規サービスインフラ構築・運用
+* 外部サービスとの連携エラー検知基盤の設計、構築 (Lambda, EventBridge, Datadog)
 * Aurora MySQLのパフォーマンス最適化
 * BigQuery等を用いたデータ集計基盤の設計/構築
-* 新規サービスインフラ構築・運用
-* CIOps（GitHub Actions → ECR → ECS）からGitOps (PipeCD) への移行設計・実装
-* Datadogを用いた可観測性を担う仕組みの構築、推進
 * TiDB移行調査/検討
-* PipeCDを用いたcanary release / progressive deliveryの導入
-* 外部サービスとの連携エラー検知基盤の設計、構築 (Lambda, EventBridge, Datadog)
 * 顧客のキャンペーンに伴う負荷対策
 * AI活用のための基盤構築
 * 各種障害対応、オンコール
@@ -111,12 +111,12 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 
 #### 基幹システムリプレイスのリードSRE
 
-* ドメイン知識のキャッチアップと要件への落とし込み
 * Kafka (Amazon MSK等)を用いたデータ連携方式のPoC、設計、構築
-* タスク/スケジュールの管理
+* ドメイン知識のキャッチアップと要件への落とし込み
 * RDBの論理設計
+* タスク/スケジュールの管理
 * リリースフローの構築と開発チームへのレクチャー
-* セキュリティ等各種ガイドラインの遵守
+* 社内のセキュリティ・コンプライアンスガイドラインの遵守
 * SREや開発チームへのリプレイス後技術のレクチャー
 * リリース前負荷試験の実施
 
@@ -124,10 +124,6 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 
 * マイクロサービス基盤上でのNodeJSアプリケーションの設計、構築、運用
 * AkamaiでのWAFやルーティングの設計
-* リリースフローの構築と開発チームへのレクチャー
-* セキュリティ等各種ガイドラインの遵守
-* SREや開発チームへのリプレイス後の技術のレクチャー
-* リリース前負荷試験の実施
 
 ### 株式会社エス・エム・エス
 
@@ -167,6 +163,8 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 
 業務委託として2018年4月〜2021年6月の間フルリモートで従事
 
+1on1 支援ツール TeamUp を運営するチームを業務委託で支援し、インフラ整備と開発体制づくりを担当
+
 #### 1 on 1ツールTeamUpのインフラ整備、開発体制の仕組み化支援
 
 2018年4月〜2021年6月
@@ -185,26 +183,28 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 
 正社員として2015年4月〜2017年9月の間勤務
 
+エンジニア向け Q&A サービス「teratail」を中心に、Web アプリ開発・インフラ・データ分析基盤まで横断的に担当
+
 #### エンジニア向けQ&Aサービス「teratail」の開発ほか
 
 2015年4月〜2017年9月
 
 * CakePHPアプリケーションの機能開発、メンテナンス
 * 公開REST APIの設計、構築
+* VPCからGKE(Kubernetes)環境への移行
+* アプリケーション全体のパフォーマンス改善
 * キャンペーンページのフロントエンド全体の開発
 * CI環境の整備
 * 事業目標達成のための施策検討
 * Elasticsearch, Redshift, BigQuery等を使った分析基盤の構築
-* VPCからGKE(Kubernetes)環境への移行
-* アプリケーション全体のパフォーマンス改善
 * メールマガジンのシステム（Mailchimp）の導入とアプリとの接続
 * 純広告のシステム（Google Adwords）の導入と管理
+* 2015年度Excellent Hacker賞受賞
 * その他
   * 社内ネットワークの設計、構築、管理
   * 記事コンテンツの執筆
   * メールマガジン等のコンテンツの構築・ディレクション
   * 採用活動への参加
-  * 2015年度Excellent Hacker賞受賞
 
 ### スローガン株式会社
 

--- a/resume.ja.md
+++ b/resume.ja.md
@@ -227,8 +227,6 @@ SRE のテックリードとして、飲食店向け注文管理 SaaS「Camel」
 * SoftwareDesign連載 アプリエンジニアのための［インフラ］入門 全6回 2016年
 * gihyo.jp [あとはコードを書くだけ，はじめに作る開発環境構築ベストプラクティス](https://gihyo.jp/dev/serial/01/howto-env-conf) 2016年
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎](https://gihyo.jp/dev/serial/01/js-foundation)（第3,5,7回）2015年
-* Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT) , Jan. 2014
-* Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
 
 ## 資格
 

--- a/resume.ja.md
+++ b/resume.ja.md
@@ -6,6 +6,8 @@
 
 Ikuo Degawa (@ikuwow)
 
+SRE / Platform Engineer
+
 1990年生まれ 神奈川県在住
 
 * X https://x.com/ikuwow
@@ -15,60 +17,54 @@ Ikuo Degawa (@ikuwow)
 
 この職務経歴書の最新版はGitHubにあります: https://github.com/ikuwow/resume
 
-## 技術
+## 概要
 
-* WebアプリケーションにおけるSRE, DevOpsの経験
-  * CircleCI, TravisCI, GitHub Actions等を用いたCI/CD環境の構築、メンテナンス
-  * PipeCD等を用いたGitOps・プログレッシブデリバリーの設計・運用
-  * GitHub等を用いた開発プロジェクトの管理
-  * 開発チームの体制サポート、Enabling SREの実践
-  * アプリケーションをまたいだ問題解決とプロジェクト推進
-  * 障害対応におけるリーダーシップ
-  * 50%ルール、ポストモーテム等のSREプラクティスの実施
-  * SLO/SLI, エラーバジェットポリシーの整備と運用
-  * Datadog等を用いた可観測性のための仕組みの設計・構築
-* インフラの構築管理、ミドルウェアの管理の経験
-  * ネットワークやインフラ技術の基礎的な知識
-  * AWS, GCP等のクラウドプラットフォームの活用
-  * Terraform、Ansible、Chef等を使ったIaCによる構成管理の環境の構築、運用
-  * 本番環境におけるDocker, Kubernetes, ECSの経験
-  * Kubernetes・Istioを使ったマイクロサービスアーキテクチャの設計・構築・運用
-  * マイクロサービス環境でのアプリケーションの運用
-  * PostgreSQL, MySQL等のRDBの設計、パフォーマンス改善、管理
-  * オフィスネットワーク構築
-* バックエンド開発の能力
-  * PHP, Ruby, Java, JavaScript, Golang等のプログラミング言語の経験
-  * CakePHP, Ruby on Rails, Spring等のフレームワークの経験
-* フロントエンド開発の能力
-  * HTML/CSS/JavaScriptを使ったフロントエンド開発の経験
-  * Sass, Webpackを使ったフロントエンドプロジェクトの構築、メンテナンス
-  * パフォーマンスモニタリングと改善
-  * RUMツールを用いたフロントエンド観測の仕組みの構築
-* その他
-  * Elasticsearch, Kibana, Redshift, BigQuery, Tableau等を使ったデータ分析環境の構築
-  * SwiftによるiOSアプリの開発経験
-  * MATLABとC言語による画像処理・音声処理プログラミング
-  * WordPress等CMSのカスタマイズ
+Web系企業で SRE・プラットフォームエンジニアとして、サービスの信頼性とデリバリー基盤づくりに長く携わってきました。AWS を基盤とした SLO/SLI 運用、GitOps・プログレッシブデリバリー、Kubernetes・Istio によるマイクロサービス基盤の設計・構築・運用を得意としています。職種や技術領域をまたいで、技術・組織・コストのトレードオフを踏まえた全体最適な問題解決に取り組み、常にプロジェクトやサービスの目的とユーザーへの価値を見据えて行動することを大切にしています。GitHub やドキュメンテーション・メッセージングツールを活用した非同期コミュニケーションを基本としています。現在は飲食店向け SaaS「Camel」のテックリードとして、信頼性・デリバリー・コストを横断的に推進しています。
+
+## スキル
+
+習熟度の高い順に記載しています。
+
+### コア（信頼性・デリバリー基盤）
+
+* SRE / DevOps の実践（CI/CD 環境の構築・運用、障害対応のリーダーシップ、ポストモーテムや50%ルール等のプラクティス、Enabling SRE）
+* SLO/SLI・エラーバジェットポリシーの整備と運用
+* 可観測性のための仕組みの設計・構築（Datadog 等）
+* GitOps・プログレッシブデリバリーの設計・運用（PipeCD, Flagger, Flux 等）
+* Kubernetes・Istio によるマイクロサービスアーキテクチャの設計・構築・運用
+* AWS を中心としたクラウドインフラの構築・運用
+* Golang によるバックエンドアプリケーションの開発・運用
+* 手を動かした技術検証・PoC
+* AIコーディングエージェントの活用、およびAIエージェントを前提とした開発プロセスの設計・導入
+
+### 実務経験
+
+* プログラミング言語: PHP, Ruby, Java, JavaScript, Golang
+* フレームワーク: CakePHP, Ruby on Rails, Spring
+* IaC・構成管理: Terraform, Ansible, Chef
+* コンテナ・オーケストレーション: Docker, Kubernetes, ECS
+* クラウド: AWS, GCP
+* RDB: PostgreSQL, MySQL の設計・パフォーマンス改善・管理
+* フロントエンド: HTML/CSS/JavaScript, Sass, Webpack、RUM ツールによる観測とパフォーマンス改善
+* データ分析基盤: Elasticsearch, Kibana, Redshift, BigQuery, Tableau
+* ネットワーク・インフラの基礎知識、オフィスネットワークの構築
+* 英語での読み書き・リスニング、技術ドキュメントの読解
+
+### バックグラウンド・周辺
+
+* MATLAB・C 言語による画像処理・音声処理プログラミング
+* Swift による iOS アプリの開発
+* WordPress 等 CMS のカスタマイズ
 
 <div class="page-break"></div>
-
-## できること
-
-* 常にプロジェクトやサービスの目的を見据えて行動する
-* 職種や技術領域をまたいだ、技術・組織・コストのトレードオフを踏まえた全体最適な問題解決
-* 手を動かして技術検証/PoCができる
-* AIコーディングエージェントの活用、環境整備
-* AIエージェントを前提とした開発プロセスの設計と導入
-* GitHubやドキュメンテーションツール、メッセージングツールによるスムーズな非同期コミュニケーション
-* モラルとユーザーへの価値を大事にする
-* 英語の読み書き、リスニング
-* OSSへの貢献
 
 ## 職務経歴
 
 ### 株式会社tacoms
 
 業務委託として2024年6月〜2025年7月、正社員として2025年8月から現在まで勤務
+
+飲食店向け注文管理 SaaS「Camel」のテックリードとして、信頼性・デリバリー・コストを横断的に推進
 
 #### SREメンバー/テックリード
 
@@ -101,6 +97,8 @@ Ikuo Degawa (@ikuwow)
 ### 株式会社ZOZO
 
 正社員として2021年12月〜2024年4月の間フルリモートで勤務
+
+大規模ECのプラットフォームSRE、および基幹システムリプレイスのリードSREを担当
 
 #### プラットフォームサービスSREブロック, Front SREブロック
 
@@ -140,6 +138,8 @@ Ikuo Degawa (@ikuwow)
 
 正社員として2017年10月〜2021年11月の間勤務
 （2020年よりフルリモート勤務）
+
+介護経営支援 SaaS「カイポケ」をはじめとする複数サービスの SRE を担当
 
 #### 社内向けLPホスティングサービスの開発、サポートほか
 
@@ -224,7 +224,7 @@ Ikuo Degawa (@ikuwow)
 * iOSアプリの新規開発
 * 学生エンジニア向けセミナー講師
 
-## 執筆
+## 執筆・発表・OSS
 
 * [tacoms テックブログ](https://tacoms-inc.hatenablog.com/archive/author/ikuwow) テックブログ執筆 2024年〜
 * [旧tacoms テックブログ](https://zenn.dev/p/tacoms) テックブログ執筆
@@ -234,6 +234,7 @@ Ikuo Degawa (@ikuwow)
 * gihyo.jp [聞いたら一生の宝，プログラミングの基礎の基礎](https://gihyo.jp/dev/serial/01/js-foundation)（第3,5,7回）2015年
 * Ikuo Degawa, Taichi Yoshida, Kazu Mishiba, Masaaki Ikehara, Single Image Super Resolution by l2 Approximation without Learning in International Workshop on Advanced Image Technology (IWAIT) , Jan. 2014
 * Ikuo Degawa, Kei Sato, and Masaaki Ikehara, Multipitch estimation and instrument recognition by exemplar-based sparse representation, Proc. of IEEE ACSSC 2013, Pacific Grove, CA, Nov. 2013.
+* [GitHub](https://github.com/ikuwow) 上での OSS へのコントリビュート
 
 ## 資格
 


### PR DESCRIPTION
## 目的

resume.ja.md を「雰囲気はポートフォリオ、中身は職務経歴書」の構成に再構成する。従来は冒頭がいきなり技術スキルの長い入れ子で始まり、読み手が「何屋か」を掴むのに職歴を読み解く必要があった。冒頭に概要を置き、スキルを習熟度で階層化し、各社のハイライトを前に出して、上から読んで主戦場（SRE / Platform Engineer）が即座に伝わる形にする。

設計方針は本人レビューを重ねて確定した（統合見出しは「概要」、見出しは日本語、実務年数は数字を断定せずぼかす）。

## 変更の要点

- ヘッダに肩書きラベル `SRE / Platform Engineer` を追加
- 概要セクションを新設（ヘッダ直後）。何屋か・得意領域・仕事の進め方を中立トーンで定義。特定企業名は入れず個人の説明に寄せる
- 旧「技術」を コア / 実務経験 / バックグラウンド の3階層に再編。実務経験はカテゴリ集約。旧「できること」を解体し、姿勢系は概要へ、スキル系（PoC・AIエージェント活用・英語等）はスキルへ振り分け
- 職務経歴は既存の内容を維持しつつ、各社のハイライト（GitOps移行・Kafkaデータ連携・GKE移行 等）を箇条書き先頭に並べ替え、各社に文脈一言を追加。ZOZO の2プロジェクト間で重複していた記述を整理し、フロントエンドリプレイスは固有項目のみに削減
- 執筆セクションを整理（現在のキャリアと接続が薄い学生時代の論文2本と、具体性の乏しい OSS 一行を削除）
- 英語版（resume.en.md）を ja の新構成へ翻訳同期。あわせて機械翻訳由来の不自然な表現（"lecturing"→training、"foundations"→platforms、組織ジャーゴン "Block"→teams 等）を英語として自然な表現に修正

誇張・盛りはしない（public 常設・知人も読む前提）。

## スコープ

- resume.ja.md（マスター）と resume.en.md（英語ミラー）を同一 PR で更新
- 英語 prose / Markdown の体裁チェック（IntelliJ が出す類の指摘）は本 PR のスコープ外
- 各ボレットを成果・定量ベースに書き換える改善は、検証可能な指標の棚卸しを要するため本 PR とは分離（follow-up）

## Verification

- [x] resume.ja.md / resume.en.md の構成・箇条書きのパリティを確認（見出し25個が1:1で対応）
- [x] 概要・各社の文脈一言の事実整合を本人と確認（年数のぼかし、tacoms = SRE のテックリード等）
- [x] PDF レイアウト（page-break 位置）の最終確認。CI が macOS で artifact を生成するので、本人がそれを確認
